### PR TITLE
Fix not working "once" simulation

### DIFF
--- a/src/emitter.test.ts
+++ b/src/emitter.test.ts
@@ -38,6 +38,23 @@ describe('Emitter', () => {
       expect(emit.listeners.has('boom')).toBeTruthy();
       expect(emit.listeners.get('boom')).toEqual([rick, morty]);
     });
+
+    it('can simulate "once"', () => {
+      const counter = jest.fn();
+      const handlers = [1, 2, 3, 4, 5].map(i => {
+        // create .once fn
+        function fn() {
+          emit.off('once', fn);
+          counter();
+        }
+        return fn;
+      });
+      handlers.forEach(fn => emit.on('once', fn));
+      emit.emit('once');
+      expect(emit.listeners.has('once')).toBeTruthy();
+      expect(emit.listeners.get('once')).toEqual([]);
+      expect(counter).toHaveBeenCalledTimes(5);
+    });
   });
 
   describe('.off', () => {

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -19,6 +19,6 @@ export default class Emitter {
 
   emit(type: string, payload: any) {
     const listeners = this.listeners.has(type) && this.listeners.get(type);
-    listeners && listeners.forEach(callback => callback(payload));
+    listeners && listeners.slice().forEach(callback => callback(payload));
   }
 }


### PR DESCRIPTION
When i try to remove multiple handlers immediately it won't remove all of them. This PR fixes that.